### PR TITLE
improve parallelism during concurrent recovery of multiple persistence unit

### DIFF
--- a/src/main/scala/akka/persistence/kafka/MessageIterator.scala
+++ b/src/main/scala/akka/persistence/kafka/MessageIterator.scala
@@ -4,6 +4,7 @@ import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.JavaConverters._
+import scala.concurrent.blocking
 
 class MessageIterator(consumerConfig: Map[String, Object], topic: String, partition: Int, offset: Long, timeOut: Long)
     extends Iterator[ConsumerRecord[String, Array[Byte]]] {
@@ -17,7 +18,7 @@ class MessageIterator(consumerConfig: Map[String, Object], topic: String, partit
     val tp = new TopicPartition(topic, partition)
     consumer.assign(List(tp).asJava)
     consumer.seek(tp, offset)
-    val it = consumer.poll(timeOut).iterator().asScala
+    val it = blocking { consumer.poll(timeOut).iterator().asScala }
     it
   }
 

--- a/src/main/scala/akka/persistence/kafka/MetadataConsumer.scala
+++ b/src/main/scala/akka/persistence/kafka/MetadataConsumer.scala
@@ -4,10 +4,11 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.JavaConverters._
+import scala.concurrent.blocking
 
 trait MetadataConsumer {
 
-  def nextOffsetFor(config: Map[String, Object], topic: String, partition: Int): Long = {
+  def nextOffsetFor(config: Map[String, Object], topic: String, partition: Int): Long = blocking {
     val tp       = new TopicPartition(topic, partition)
     val consumer = new KafkaConsumer[String, Array[Byte]](config.asJava)
     try {

--- a/src/main/scala/akka/persistence/kafka/journal/KafkaJournal.scala
+++ b/src/main/scala/akka/persistence/kafka/journal/KafkaJournal.scala
@@ -42,12 +42,10 @@ class KafkaJournal extends AsyncWriteJournal with MetadataConsumer with ActorLog
 
   private def localReceive: Receive = {
     case ReadHighestSequenceNr(_, persistenceId, _) ⇒
-      try {
-        val highest = readHighestSequenceNr(persistenceId)
-        sender ! ReadHighestSequenceNrSuccess(highest)
-      } catch {
-        case e: Exception ⇒ sender ! ReadHighestSequenceNrFailure(e)
-      }
+      import akka.pattern.pipe
+      Future(ReadHighestSequenceNrSuccess(readHighestSequenceNr(persistenceId)))
+        .recover { case t ⇒ ReadHighestSequenceNrFailure(t) }
+        .pipeTo(sender())
   }
 
   // --------------------------------------------------------------------------------------


### PR DESCRIPTION
this solves some timeout issue on slow machines:

```
akka.pattern.AskTimeoutException: Ask timed out on [Actor[akka://ccp/system/kafka-journal#-468168491]] after [5000 ms]. Sender[Actor[akka://ccp/system/kafka-snapshot-store#1762987524]] sent message of type "akka.persistence.kafka.journal.KafkaJournalProtocol$ReadHighestSe
quenceNr".
        at akka.pattern.PromiseActorRef$.$anonfun$defaultOnTimeout$1(AskSupport.scala:596)
        at akka.pattern.PromiseActorRef$.$anonfun$apply$1(AskSupport.scala:606)
        at akka.actor.Scheduler$$anon$4.run(Scheduler.scala:205)
        at scala.concurrent.Future$InternalCallbackExecutor$.unbatchedExecute(Future.scala:870)
        at scala.concurrent.BatchingExecutor.execute(BatchingExecutor.scala:109)
        at scala.concurrent.BatchingExecutor.execute$(BatchingExecutor.scala:103)
        at scala.concurrent.Future$InternalCallbackExecutor$.execute(Future.scala:868)
        at akka.actor.LightArrayRevolverScheduler$TaskHolder.executeTask(LightArrayRevolverScheduler.scala:328)
        at akka.actor.LightArrayRevolverScheduler$$anon$4.executeBucket$1(LightArrayRevolverScheduler.scala:279)
        at akka.actor.LightArrayRevolverScheduler$$anon$4.nextTick(LightArrayRevolverScheduler.scala:283)
        at akka.actor.LightArrayRevolverScheduler$$anon$4.run(LightArrayRevolverScheduler.scala:235)
        at java.lang.Thread.run(Thread.java:748)

```